### PR TITLE
Make cards smaller

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,7 +15,7 @@
 }
 
 .Card svg {
-  height: 25vmax;
+  height: 30vmin;
   flex: auto;
 }
 


### PR DESCRIPTION
Maybe cards should be sized based on the smaller of width and height, instead of the larger of the two?See #3.